### PR TITLE
feat: Token2022

### DIFF
--- a/programs/order-engine/Cargo.toml
+++ b/programs/order-engine/Cargo.toml
@@ -28,7 +28,7 @@ check-cfg = [
 
 [dependencies]
 anchor-lang = { workspace = true }
-anchor-spl = { workspace = true }
+anchor-spl = { workspace = true, features = ["token_2022"] }
 test-case = { workspace = true }
 
 [dev-dependencies]

--- a/programs/order-engine/src/error.rs
+++ b/programs/order-engine/src/error.rs
@@ -4,4 +4,5 @@ use anchor_lang::error_code;
 pub enum OrderEngineError {
     InvalidCalculation,
     MissingTemporaryWrappedSolTokenAccount,
+    Token2022MintExtensionNotSupported,
 }

--- a/programs/order-engine/src/lib.rs
+++ b/programs/order-engine/src/lib.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-mod error;
+pub mod error;
 mod instructions;
 
 use instructions::*;


### PR DESCRIPTION
Allow token2022 usage in the order engine

~~While blocking dangerous/breaking extensions. Alternatively we could strip all the validation and only care about transfer fee non zero and leave it to the market maker not to brick themselves on transfer preventing extensions~~ Changed to  letting it fail on unexpected extension while ensuring no incorrect accounting by checking transfer fee

