### PR TITLE
update quote service url and adjust api endpoints in integration tests

### DIFF
--- a/tests/params.ts
+++ b/tests/params.ts
@@ -3,7 +3,7 @@ export const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 export const WSOL = 'So11111111111111111111111111111111111111112';
 
 // Base API URL, load from environment variable or use default
-export const QUOTE_SERVICE_URL = process.env.QUOTE_SERVICE_URL || 'https://quote-proxy-edge.raccoons.dev';
+export const QUOTE_SERVICE_URL = process.env.QUOTE_SERVICE_URL || 'https://preprod.ultra-api.jup.ag';
 export const WEBHOOK_ID = process.env.WEBHOOK_ID || false; // webhook id
 export const TAKER_KEYPAIR = process.env.TAKER_KEYPAIR || "keypair.json"; // taker private key
 export const AMOUNT = process.env.AMOUNT || 1_000_000;

--- a/tests/suites/integration/quote.ts
+++ b/tests/suites/integration/quote.ts
@@ -46,14 +46,12 @@ describe('Webhook e2e API Quote', () => {
         expect(response.data).toHaveProperty('quoteId');
         expect(response.data).toHaveProperty('requestId');
         expect(response.data).toHaveProperty('expireAt');
-        expect(response.data).toHaveProperty('orderInfo');
         expect(response.data).toHaveProperty('maker');
-        expect(response.data).toHaveProperty('orderInfo');
         expect(response.data.swapMode).toBe(payload.swapMode);
-        expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-        expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
-        expect(new BN(response.data.orderInfo.output.endAmount).gt(new BN(0))).toBe(true);
-        expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
+        expect(response.data.inAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.inputMint).toBe(params.MINT_B);
+        expect(new BN(response.data.outAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.outputMint).toBe(params.MINT_A);
       })
       .catch((error) => {
         if (error.response) {
@@ -108,14 +106,12 @@ describe('Webhook e2e API Quote', () => {
         expect(response.data).toHaveProperty('quoteId');
         expect(response.data).toHaveProperty('requestId');
         expect(response.data).toHaveProperty('expireAt');
-        expect(response.data).toHaveProperty('orderInfo');
         expect(response.data).toHaveProperty('maker');
-        expect(response.data).toHaveProperty('orderInfo');
         expect(response.data.swapMode).toBe(payload.swapMode);
-        expect(new BN(response.data.orderInfo.input.endAmount).gt(new BN(0))).toBe(true);
-        expect(response.data.orderInfo.input.token).toBe(params.MINT_A);
-        expect(response.data.orderInfo.output.endAmount).toBe(`${params.AMOUNT}`);
-        expect(response.data.orderInfo.output.token).toBe(params.MINT_B);
+        expect(new BN(response.data.inAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.inputMint).toBe(params.MINT_A);
+        expect(response.data.outAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.outputMint).toBe(params.MINT_B);
       })
       .catch((error) => {
         if (error.response) {
@@ -164,13 +160,11 @@ describe('Webhook e2e API Quote', () => {
         expect(response.data).toHaveProperty('quoteId');
         expect(response.data).toHaveProperty('requestId');
         expect(response.data).toHaveProperty('expireAt');
-        expect(response.data).toHaveProperty('orderInfo');
         expect(response.data).toHaveProperty('maker'); // the maker should be the MM address
-        expect(response.data).toHaveProperty('orderInfo');
-        expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-        expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
-        expect(new BN(response.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
-        expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
+        expect(response.data.inAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.inputMint).toBe(params.MINT_B);
+        expect(new BN(response.data.outAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.outputMint).toBe(params.MINT_A);
       })
       .catch((error) => {
         if (error.response) {

--- a/tests/suites/integration/quote.ts
+++ b/tests/suites/integration/quote.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { assert } from 'chai';
 import { describe, expect, it } from 'vitest';
 import * as params from '../../params';
-import {loadKeypairFromFile} from '../../helpers';
-import {BN} from 'bn.js';
+import { loadKeypairFromFile } from '../../helpers';
+import { BN } from 'bn.js';
 
 // Start mock server before tests and close it after
 describe('Webhook e2e API Quote', () => {
@@ -19,46 +19,53 @@ describe('Webhook e2e API Quote', () => {
     const taker = keypair.address;
     console.log('taker address: ', taker);
 
-    const url = `${params.QUOTE_SERVICE_URL}/quote`;
+    const url = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', url);
 
     const payload = {
-      swapMode: "exactIn",
-      taker: taker,
       inputMint: params.MINT_B,
       outputMint: params.MINT_A,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
-      webhookId: params.WEBHOOK_ID,
+      mode: "manual",
+      swapMode: "ExactIn",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      taker: taker,
+      webhookId: params.WEBHOOK_ID
     }
 
     await axios.get(url, { params: payload })
-    .then((response) => {
-      console.log("response --> ", response.data);
-      expect(response.status).toBe(200);
-      expect(response.data).toHaveProperty('quoteId');
-      expect(response.data).toHaveProperty('requestId');
-      expect(response.data).toHaveProperty('expireAt');
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data).toHaveProperty('maker');
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data.swapMode).toBe(payload.swapMode);
-      expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-      expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
-      expect(new BN(response.data.orderInfo.output.endAmount).gt(new BN(0))).toBe(true);
-      expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
-    })
-    .catch((error) => {
-      if(error.response) {
-        console.log("error.response.data --> ", error.response.data);
-        assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
-      } else if(error.request) {
-        assert.fail(`failed to get quote: no response from server ${error.config.url}`);
-      } else {
-        console.log("error --> ", error);
-        assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
-      }
-    });
+      .then((response) => {
+        console.log("response --> ", response.data);
+        expect(response.status).toBe(200);
+        expect(response.data).toHaveProperty('quoteId');
+        expect(response.data).toHaveProperty('requestId');
+        expect(response.data).toHaveProperty('expireAt');
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data).toHaveProperty('maker');
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data.swapMode).toBe(payload.swapMode);
+        expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
+        expect(new BN(response.data.orderInfo.output.endAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
+      })
+      .catch((error) => {
+        if (error.response) {
+          console.log("error.response.data --> ", error.response.data);
+          assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
+        } else if (error.request) {
+          assert.fail(`failed to get quote: no response from server ${error.config.url}`);
+        } else {
+          console.log("error --> ", error);
+          assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
+        }
+      });
   });
 
   it('should return a successful quote response (ExactOut)', async () => {
@@ -73,46 +80,54 @@ describe('Webhook e2e API Quote', () => {
     const taker = keypair.address;
     console.log('taker address: ', taker);
 
-    const url = `${params.QUOTE_SERVICE_URL}/quote`;
+    const url = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', url);
 
     const payload = {
-      swapMode: "exactOut",
-      taker: taker,
       inputMint: params.MINT_A,
       outputMint: params.MINT_B,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
-      webhookId: params.WEBHOOK_ID,
+      mode: "manual",
+      swapMode: "ExactOut",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      webhookId: params.WEBHOOK_ID
     }
 
+
+
     const response = await axios.get(url, { params: payload })
-    .then((response) => {
-      console.log("response --> ", response.data);
-      expect(response.status).toBe(200);
-      expect(response.data).toHaveProperty('quoteId');
-      expect(response.data).toHaveProperty('requestId');
-      expect(response.data).toHaveProperty('expireAt');
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data).toHaveProperty('maker');
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data.swapMode).toBe(payload.swapMode);
-      expect(new BN(response.data.orderInfo.input.endAmount).gt(new BN(0))).toBe(true);
-      expect(response.data.orderInfo.input.token).toBe(params.MINT_A);
-      expect(response.data.orderInfo.output.endAmount).toBe(`${params.AMOUNT}`);
-      expect(response.data.orderInfo.output.token).toBe(params.MINT_B);
-    })
-    .catch((error) => {
-      if(error.response) {
-        console.log("error.response.data --> ", error.response.data);
-        assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
-      } else if(error.request) {
-        assert.fail(`failed to get quote: no response from server ${error.config.url}`);
-      } else {
-        console.log("error --> ", error);
-        assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
-      }
-    });
+      .then((response) => {
+        console.log("response --> ", response.data);
+        expect(response.status).toBe(200);
+        expect(response.data).toHaveProperty('quoteId');
+        expect(response.data).toHaveProperty('requestId');
+        expect(response.data).toHaveProperty('expireAt');
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data).toHaveProperty('maker');
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data.swapMode).toBe(payload.swapMode);
+        expect(new BN(response.data.orderInfo.input.endAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.orderInfo.input.token).toBe(params.MINT_A);
+        expect(response.data.orderInfo.output.endAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.orderInfo.output.token).toBe(params.MINT_B);
+      })
+      .catch((error) => {
+        if (error.response) {
+          console.log("error.response.data --> ", error.response.data);
+          assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
+        } else if (error.request) {
+          assert.fail(`failed to get quote: no response from server ${error.config.url}`);
+        } else {
+          console.log("error --> ", error);
+          assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
+        }
+      });
   });
 
   it('should return a successful quote response (with an empty taker) - ExactIn', async () => {
@@ -121,42 +136,52 @@ describe('Webhook e2e API Quote', () => {
 
     console.log(`how many ${params.MINT_A} can you get for ${params.AMOUNT} of ${params.MINT_B}?`);
 
-    const url = `${params.QUOTE_SERVICE_URL}/quote`;
+    const url = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', url);
 
     const payload = {
       inputMint: params.MINT_B,
       outputMint: params.MINT_A,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
-      webhookId: params.WEBHOOK_ID,
+      mode: "manual",
+      swapMode: "ExactIn",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      webhookId: params.WEBHOOK_ID
     }
 
+
+
     const response = await axios.get(url, { params: payload })
-    .then((response) => {
-      console.log("response --> ", response.data);
-      expect(response.status).toBe(200);
-      expect(response.data).toHaveProperty('quoteId');
-      expect(response.data).toHaveProperty('requestId');
-      expect(response.data).toHaveProperty('expireAt');
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data).toHaveProperty('maker'); // the maker should be the MM address
-      expect(response.data).toHaveProperty('orderInfo');
-      expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-      expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
-      expect(new BN(response.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
-      expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
-    })
-    .catch((error) => {
-      if(error.response) {
-        console.log("error.response.data --> ", error.response.data);
-        assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
-      } else if(error.request) {
-        assert.fail(`failed to get quote: no response from server ${error.config.url}`);
-      } else {
-        console.log("error --> ", error);
-        assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
-      }
-    });
+      .then((response) => {
+        console.log("response --> ", response.data);
+        expect(response.status).toBe(200);
+        expect(response.data).toHaveProperty('quoteId');
+        expect(response.data).toHaveProperty('requestId');
+        expect(response.data).toHaveProperty('expireAt');
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data).toHaveProperty('maker'); // the maker should be the MM address
+        expect(response.data).toHaveProperty('orderInfo');
+        expect(response.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
+        expect(response.data.orderInfo.input.token).toBe(params.MINT_B);
+        expect(new BN(response.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
+        expect(response.data.orderInfo.output.token).toBe(params.MINT_A);
+      })
+      .catch((error) => {
+        if (error.response) {
+          console.log("error.response.data --> ", error.response.data);
+          assert.fail(`failed to get quote: unexpected response status ${error.response.status}: ${error.response.data.error}`);
+        } else if (error.request) {
+          assert.fail(`failed to get quote: no response from server ${error.config.url}`);
+        } else {
+          console.log("error --> ", error);
+          assert.fail(`failed to get quote: unknown error for ${error.config.url}`);
+        }
+      });
   });
 });

--- a/tests/suites/integration/swap.ts
+++ b/tests/suites/integration/swap.ts
@@ -190,7 +190,7 @@ describe('Webhook e2e API Swap', {
 
       // Assertions for the swap response
       expect(swapResponse.status).toBe(200);
-      expect(swapResponse.data.state).toBe("accepted");
+      expect(swapResponse.data.state).toBe("Success");
 
     } catch (error) {
       if (error.response) {
@@ -307,7 +307,7 @@ describe('Webhook e2e API Swap', {
 
       // Assertions for the swap response
       expect(swapResponse.status).toBe(200);
-      expect(swapResponse.data.state).toBe("accepted");
+      expect(swapResponse.data.state).toBe("Success");
 
     } catch (error) {
       if (error.response) {

--- a/tests/suites/integration/swap.ts
+++ b/tests/suites/integration/swap.ts
@@ -2,14 +2,14 @@ import axios from 'axios';
 import { assert } from 'chai';
 import { describe, expect, it } from 'vitest';
 import * as params from '../../params';
-import {loadKeypairFromFile} from '../../helpers';
+import { loadKeypairFromFile } from '../../helpers';
 import { KeyPairSigner, appendTransactionMessageInstruction, compileTransaction, createTransactionMessage, decompileTransactionMessage, getBase64Decoder, getBase64Encoder, getCompiledTransactionMessageDecoder, getTransactionDecoder, getTransactionEncoder, partiallySignTransaction, pipe, signTransaction } from '@solana/kit';
-import {BN} from 'bn.js';
+import { BN } from 'bn.js';
 import { getAssertAccountInfoInstruction, accountInfoAssertion, IntegerOperator } from 'lighthouse-sdk';
 describe('Webhook e2e API Swap', {
   timeout: 10_000,
   // skip: true
-},() => {
+}, () => {
   it('should execute a successful swap (ExactIn)', async () => {
 
     assert(params.WEBHOOK_ID, 'WEBHOOK_ID is not set');
@@ -22,18 +22,27 @@ describe('Webhook e2e API Swap', {
     const taker = keypair.address;
     console.log('taker address: ', taker);
 
-    const quoteURL = `${params.QUOTE_SERVICE_URL}/quote`;
+    const quoteURL = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', quoteURL);
 
     const quoteParams = {
-      swapMode: "exactIn",
-      taker: taker,
       inputMint: params.MINT_B,
       outputMint: params.MINT_A,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
+      mode: "manual",
+      swapMode: "ExactIn",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      taker: taker,
       webhookId: params.WEBHOOK_ID,
     }
+
+
 
     try {
       // Step 1: Fetch the quote
@@ -51,16 +60,16 @@ describe('Webhook e2e API Swap', {
       expect(quoteResponse.data.orderInfo.input.token).toBe(params.MINT_B);
       expect(new BN(quoteResponse.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
       expect(quoteResponse.data.orderInfo.output.token).toBe(params.MINT_A);
-     
-     
+
+
       // Step 2: Transaction signing
       const base64Transaction = quoteResponse.data.transaction;
       expect(base64Transaction).toBeDefined();
 
       const transactionBytes = getBase64Encoder().encode(base64Transaction);
       const transaction = getTransactionDecoder().decode(transactionBytes);
-      
-      
+
+
       const signedTransaction = await pipe(
         transaction,
         (tx) => partiallySignTransaction([keypair.keyPair], tx),
@@ -68,13 +77,12 @@ describe('Webhook e2e API Swap', {
 
       const signedTransactionBytes = getTransactionEncoder().encode(signedTransaction);
       const signedTransactionBase64 = getBase64Decoder().decode(signedTransactionBytes);
-      
+
       // Step 3: Send the swap transaction
-      const swapURL = `${params.QUOTE_SERVICE_URL}/swap`;
+      const swapURL = `${params.QUOTE_SERVICE_URL}/execute`;
       const swapPayload = {
-        quoteId: quoteResponse.data.quoteId,
         requestId: quoteResponse.data.requestId,
-        transaction: signedTransactionBase64,
+        signedTransaction: signedTransactionBase64,
       };
       const swapParams = { swapType: 'rfq' };
       console.log("Swap payload --> ", swapPayload);
@@ -84,7 +92,6 @@ describe('Webhook e2e API Swap', {
 
       // Assertions for the swap response
       expect(swapResponse.status).toBe(200);
-      expect(swapResponse.data.quoteId).toBe(swapPayload.quoteId);
       expect(swapResponse.data.state).toBe("accepted");
 
     } catch (error) {
@@ -118,16 +125,23 @@ describe('Webhook e2e API Swap', {
     const taker = keypair.address;
     console.log('taker address: ', taker);
 
-    const quoteURL = `${params.QUOTE_SERVICE_URL}/quote`;
+    const quoteURL = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', quoteURL);
 
     const quoteParams = {
-      swapMode: "exactOut",
-      taker: taker,
       inputMint: params.MINT_A,
       outputMint: params.MINT_B,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
+      mode: "manual",
+      swapMode: "ExactOut",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      taker: taker,
       webhookId: params.WEBHOOK_ID,
     }
 
@@ -154,7 +168,7 @@ describe('Webhook e2e API Swap', {
 
       const transactionBytes = getBase64Encoder().encode(base64Transaction);
       const transaction = getTransactionDecoder().decode(transactionBytes);
-  
+
       const signedTransaction = await pipe(
         transaction,
         (tx) => partiallySignTransaction([keypair.keyPair], tx),
@@ -164,11 +178,10 @@ describe('Webhook e2e API Swap', {
       const signedTransactionBase64 = getBase64Decoder().decode(signedTransactionBytes);
 
       // Step 3: Send the swap transaction
-      const swapURL = `${params.QUOTE_SERVICE_URL}/swap`;
+      const swapURL = `${params.QUOTE_SERVICE_URL}/execute`;
       const swapPayload = {
-        quoteId: quoteResponse.data.quoteId,
         requestId: quoteResponse.data.requestId,
-        transaction: signedTransactionBase64,
+        signedTransaction: signedTransactionBase64,
       };
       const swapParams = { swapType: 'rfq' };
       console.log("Swap payload --> ", swapPayload);
@@ -178,7 +191,6 @@ describe('Webhook e2e API Swap', {
 
       // Assertions for the swap response
       expect(swapResponse.status).toBe(200);
-      expect(swapResponse.data.quoteId).toBe(swapPayload.quoteId);
       expect(swapResponse.data.state).toBe("accepted");
 
     } catch (error) {
@@ -212,16 +224,23 @@ describe('Webhook e2e API Swap', {
     const taker = keypair.address;
     console.log('taker address: ', taker);
 
-    const quoteURL = `${params.QUOTE_SERVICE_URL}/quote`;
+    const quoteURL = `${params.QUOTE_SERVICE_URL}/order`;
     console.log('request url: ', quoteURL);
 
     const quoteParams = {
-      swapMode: "exactIn",
-      taker: taker,
       inputMint: params.MINT_B,
       outputMint: params.MINT_A,
       amount: `${params.AMOUNT}`,
-      swapType: 'rfq',
+      mode: "manual",
+      swapMode: "ExactIn",
+      slippageBps: 50,
+      broadcastFeeType: "maxCap",
+      priorityFeeLamports: 1000000,
+      useWsol: false,
+      asLegacyTransaction: false,
+      excludeDexes: "",
+      excludeRouters: "metis%2Chashflow%2Cdflow",
+      taker: taker,
       webhookId: params.WEBHOOK_ID,
     }
 
@@ -241,17 +260,17 @@ describe('Webhook e2e API Swap', {
       expect(quoteResponse.data.orderInfo.input.token).toBe(params.MINT_B);
       expect(new BN(quoteResponse.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
       expect(quoteResponse.data.orderInfo.output.token).toBe(params.MINT_A);
-      
+
 
       // Step 2: Transaction signing
       const base64Transaction = quoteResponse.data.transaction;
       expect(base64Transaction).toBeDefined();
 
-      let tx = createTransactionMessage({version: 0});
+      let tx = createTransactionMessage({ version: 0 });
 
       const transactionBytes = getBase64Encoder().encode(base64Transaction);
       const transaction = getTransactionDecoder().decode(transactionBytes);
-      const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);        
+      const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
 
       // get the maker address
       console.log('transaction signatures: ', transaction.signatures);
@@ -264,7 +283,7 @@ describe('Webhook e2e API Swap', {
           operator: IntegerOperator.GreaterThan,
         }),
       });
-      
+
       const signedTransaction = await pipe(
         compiledTransactionMessage,
         (tx) => decompileTransactionMessage(tx),
@@ -277,11 +296,10 @@ describe('Webhook e2e API Swap', {
       const signedTransactionBase64 = getBase64Decoder().decode(signedTransactionBytes);
 
       // Step 3: Send the swap transaction
-      const swapURL = `${params.QUOTE_SERVICE_URL}/swap`;
+      const swapURL = `${params.QUOTE_SERVICE_URL}/execute`;
       const swapPayload = {
-        quoteId: quoteResponse.data.quoteId,
         requestId: quoteResponse.data.requestId,
-        transaction: signedTransactionBase64,
+        signedTransaction: signedTransactionBase64,
       };
       const swapParams = { swapType: 'rfq' };
       console.log("Swap payload --> ", swapPayload);
@@ -291,7 +309,6 @@ describe('Webhook e2e API Swap', {
 
       // Assertions for the swap response
       expect(swapResponse.status).toBe(200);
-      expect(swapResponse.data.quoteId).toBe(swapPayload.quoteId);
       expect(swapResponse.data.state).toBe("accepted");
 
     } catch (error) {

--- a/tests/suites/integration/swap.ts
+++ b/tests/suites/integration/swap.ts
@@ -6,6 +6,7 @@ import { loadKeypairFromFile } from '../../helpers';
 import { KeyPairSigner, appendTransactionMessageInstruction, compileTransaction, createTransactionMessage, decompileTransactionMessage, getBase64Decoder, getBase64Encoder, getCompiledTransactionMessageDecoder, getTransactionDecoder, getTransactionEncoder, partiallySignTransaction, pipe, signTransaction } from '@solana/kit';
 import { BN } from 'bn.js';
 import { getAssertAccountInfoInstruction, accountInfoAssertion, IntegerOperator } from 'lighthouse-sdk';
+import test from 'node:test';
 describe('Webhook e2e API Swap', {
   timeout: 10_000,
   // skip: true
@@ -54,12 +55,11 @@ describe('Webhook e2e API Swap', {
       expect(quoteResponse.data).toHaveProperty('quoteId');
       expect(quoteResponse.data).toHaveProperty('requestId');
       expect(quoteResponse.data).toHaveProperty('expireAt');
-      expect(quoteResponse.data).toHaveProperty('orderInfo');
       expect(quoteResponse.data).toHaveProperty('maker');
-      expect(quoteResponse.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-      expect(quoteResponse.data.orderInfo.input.token).toBe(params.MINT_B);
-      expect(new BN(quoteResponse.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
-      expect(quoteResponse.data.orderInfo.output.token).toBe(params.MINT_A);
+      expect(quoteResponse.data.inAmount).toBe(`${params.AMOUNT}`);
+      expect(quoteResponse.data.inputMint).toBe(params.MINT_B);
+      expect(new BN(quoteResponse.data.outAmount).gt(new BN(0))).toBe(true);
+      expect(quoteResponse.data.outputMint).toBe(params.MINT_A);
 
 
       // Step 2: Transaction signing
@@ -155,12 +155,11 @@ describe('Webhook e2e API Swap', {
       expect(quoteResponse.data).toHaveProperty('quoteId');
       expect(quoteResponse.data).toHaveProperty('requestId');
       expect(quoteResponse.data).toHaveProperty('expireAt');
-      expect(quoteResponse.data).toHaveProperty('orderInfo');
       expect(quoteResponse.data).toHaveProperty('maker');
-      expect(quoteResponse.data.orderInfo.output.startAmount).toBe(`${params.AMOUNT}`);
-      expect(quoteResponse.data.orderInfo.output.token).toBe(params.MINT_B);
-      expect(new BN(quoteResponse.data.orderInfo.input.startAmount).gt(new BN(0))).toBe(true);
-      expect(quoteResponse.data.orderInfo.input.token).toBe(params.MINT_A);
+      expect(quoteResponse.data.outAmount).toBe(`${params.AMOUNT}`);
+      expect(quoteResponse.data.outputMint).toBe(params.MINT_B);
+      expect(new BN(quoteResponse.data.inAmount).gt(new BN(0))).toBe(true);
+      expect(quoteResponse.data.inputMint).toBe(params.MINT_A);
 
       // Step 2: Transaction signing
       const base64Transaction = quoteResponse.data.transaction;
@@ -254,12 +253,11 @@ describe('Webhook e2e API Swap', {
       expect(quoteResponse.data).toHaveProperty('quoteId');
       expect(quoteResponse.data).toHaveProperty('requestId');
       expect(quoteResponse.data).toHaveProperty('expireAt');
-      expect(quoteResponse.data).toHaveProperty('orderInfo');
       expect(quoteResponse.data).toHaveProperty('maker');
-      expect(quoteResponse.data.orderInfo.input.startAmount).toBe(`${params.AMOUNT}`);
-      expect(quoteResponse.data.orderInfo.input.token).toBe(params.MINT_B);
-      expect(new BN(quoteResponse.data.orderInfo.output.startAmount).gt(new BN(0))).toBe(true);
-      expect(quoteResponse.data.orderInfo.output.token).toBe(params.MINT_A);
+      expect(quoteResponse.data.inAmount).toBe(`${params.AMOUNT}`);
+      expect(quoteResponse.data.inputMint).toBe(params.MINT_B);
+      expect(new BN(quoteResponse.data.outAmount).gt(new BN(0))).toBe(true);
+      expect(quoteResponse.data.outputMint).toBe(params.MINT_A);
 
 
       // Step 2: Transaction signing


### PR DESCRIPTION
Updates the integration test suite for the webhook API to reflect changes in the API endpoints and request payloads. The main updates include changing the base URL and endpoint paths, modifying payload structures, and updating assertions in the swap tests.