### PR TITLE
chore: Remove outdated anchor-spl token_2022 use spl-token-2022

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,7 +2,7 @@ name: Quality Check
 on:
   pull_request:
     branches:
-      - "**"
+      - '**'
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rustflags: "-A warnings"
+          rustflags: '-A warnings'
       - name: Build
         run: cargo build --release
   test:
@@ -42,17 +42,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rustflags: "-A warnings"
+          rustflags: '-A warnings'
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
       - name: Run tests with coverage
         run: |
           RPC_URLS=${{ secrets.RPC_URLS }} cargo llvm-cov --release --workspace --summary-only --remap-path-prefix --json > coverage.json
       - name: Generate coverage summary
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           # Read JSON and convert it to Markdown table using jq
           echo "<details><summary>Coverage report</summary>" > coverage.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ solana-program-test = "~2"
 solana-rpc-client = "~2"
 solana-sdk = "~2"
 spl-token-client = { version = "0.16.0", default-features = false }
+spl-token-2022 = { version = "9.0.0" }
 
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"

--- a/programs/order-engine/Cargo.toml
+++ b/programs/order-engine/Cargo.toml
@@ -28,7 +28,8 @@ check-cfg = [
 
 [dependencies]
 anchor-lang = { workspace = true }
-anchor-spl = { workspace = true, features = ["token_2022"] }
+anchor-spl = { workspace = true }
+spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-sdk = { workspace = true }
@@ -36,7 +37,6 @@ solana-program-test = { workspace = true }
 agave-feature-set = "~2"
 bincode = { workspace = true }
 spl-token-client = { workspace = true, default-features = false }
-spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 assert_matches = { workspace = true }
 itertools = { workspace = true }
 test-case = { workspace = true }

--- a/programs/order-engine/src/instructions/fill.rs
+++ b/programs/order-engine/src/instructions/fill.rs
@@ -5,13 +5,11 @@ use anchor_spl::{
         self,
         spl_token::{self, native_mint},
     },
-    token_2022::spl_token_2022::{
-        self,
-        extension::{
-            transfer_fee::TransferFeeConfig, BaseStateWithExtensions, StateWithExtensions,
-        },
-    },
     token_interface::{self, spl_pod::primitives::PodU16, TokenAccount, TokenInterface},
+};
+use spl_token_2022::{
+    self,
+    extension::{transfer_fee::TransferFeeConfig, BaseStateWithExtensions, StateWithExtensions},
 };
 
 use crate::error::OrderEngineError;


### PR DESCRIPTION
anchor pinned spl-token-2022 is outdated and does not have the new token extensions.
Due to a bug, getting a given extension requires the sdk to be able to understand all other extensions in the tlv data.

https://github.com/solana-program/token-2022/issues/545

So we remove the anchor-spl feature and use the latest directly instead

close https://github.com/jup-ag/rfq-webhook-toolkit/pull/48 if this is merged